### PR TITLE
Implement hybrid ksk

### DIFF
--- a/src/core_crypto/modulus/mod.rs
+++ b/src/core_crypto/modulus/mod.rs
@@ -30,15 +30,25 @@ pub trait ModulusArithmeticBackend<Scalar: UnsignedInteger> {
         self.modulus() - a
     }
 
+    fn neg_lazy_mod_fast(&self, a: Scalar) -> Scalar {
+        debug_assert!(
+            a < self.twice_modulus(),
+            "Input {a} > (2*modulus){}",
+            self.twice_modulus()
+        );
+
+        self.twice_modulus() - a
+    }
+
     fn add_mod_fast(&self, a: Scalar, b: Scalar) -> Scalar {
         debug_assert!(
             a <= self.modulus(),
-            "Input {a} > (modulus){}",
+            "Input a:{a} > (modulus){}",
             self.modulus()
         );
         debug_assert!(
             b <= self.modulus(),
-            "Input {b} > (modulus){}",
+            "Input b:{b} > (modulus){}",
             self.modulus()
         );
 
@@ -55,12 +65,12 @@ pub trait ModulusArithmeticBackend<Scalar: UnsignedInteger> {
     fn add_lazy_mod_fast(&self, a: Scalar, b: Scalar) -> Scalar {
         debug_assert!(
             a <= self.twice_modulus(),
-            "Input {a} > (2*modulus){}",
+            "Input a:{a} > (2*modulus){}",
             self.twice_modulus()
         );
         debug_assert!(
             b <= self.twice_modulus(),
-            "Input {b} > (2*modulus){}",
+            "Input b:{b} > (2*modulus){}",
             self.twice_modulus()
         );
 
@@ -75,13 +85,13 @@ pub trait ModulusArithmeticBackend<Scalar: UnsignedInteger> {
 
     fn sub_mod_fast(&self, a: Scalar, b: Scalar) -> Scalar {
         debug_assert!(
-            a < self.modulus(),
-            "Input {a} >= (modulus){}",
+            a <= self.modulus(),
+            "Input a:{a} > (modulus){}",
             self.modulus()
         );
         debug_assert!(
-            b < self.modulus(),
-            "Input {b} >= (modulus){}",
+            b <= self.modulus(),
+            "Input b:{b} > (modulus){}",
             self.modulus()
         );
 
@@ -89,6 +99,25 @@ pub trait ModulusArithmeticBackend<Scalar: UnsignedInteger> {
             a - b
         } else {
             (a + self.modulus()) - b
+        }
+    }
+
+    fn sub_lazy_mod_fast(&self, a: Scalar, b: Scalar) -> Scalar {
+        debug_assert!(
+            a <= self.twice_modulus(),
+            "Input a:{a} > (2*modulus){}",
+            self.twice_modulus()
+        );
+        debug_assert!(
+            b <= self.twice_modulus(),
+            "Input b:{b} > (2*modulus){}",
+            self.twice_modulus()
+        );
+
+        if a >= b {
+            a - b
+        } else {
+            (a + self.twice_modulus()) - b
         }
     }
 }
@@ -104,13 +133,23 @@ where
     fn add_mod_vec(&self, a: &mut [Scalar], b: &[Scalar]);
     fn sub_mod_vec(&self, a: &mut [Scalar], b: &[Scalar]);
     fn mul_mod_vec(&self, a: &mut [Scalar], b: &[Scalar]);
+    fn scalar_mul_mod_vec(&self, a: &mut [Scalar], b: Scalar);
+
+    /// Inplace reduce elemnts of vector `a` in range [0, 2q) to
+    /// [0, 2q)
+    fn reduce_from_lazy_vec(&self, a: &mut [Scalar]);
 
     /// Inplace modular multiplication a=a*b. Input a nad b are in range [0, 2q)
     /// and output a is in range [0, 2q]
     fn mul_lazy_mod_vec(&self, a: &mut [Scalar], b: &[Scalar]);
-    /// Inplace modular addition a=a+b. Input a nad b are in range [0, 2q) and
+    /// Inplace modular addition a=a+b. Input a and b are in range [0, 2q) and
     /// output a is in range [0, 2q]
     fn add_lazy_mod_vec(&self, a: &mut [Scalar], b: &[Scalar]);
-
-    fn scalar_mul_mod_vec(&self, a: &mut [Scalar], b: Scalar);
+    /// Inplace modular subtraction a=a+b. Input a and b are in range [0, 2q)
+    /// and output a is in range [0, 2q]
+    fn sub_lazy_mod_vec(&self, a: &mut [Scalar], b: &[Scalar]);
+    /// Inplace scalar modular multiplication a=a*b. Input a and b are in range
+    /// [0, 2q) and output a is in range [0, 2q]
+    fn scalar_mul_lazy_mod_vec(&self, a: &mut [Scalar], b: Scalar);
+    fn neg_lazy_mod_vec(&self, a: &mut [Scalar]);
 }

--- a/src/core_crypto/prime.rs
+++ b/src/core_crypto/prime.rs
@@ -79,8 +79,17 @@ pub(crate) fn find_primitive_root<R: RngCore>(q: u64, n: u64, rng: &mut R) -> Op
         // \omega = \omega^t. \omega is now n^th root of unity
         omega = mod_exponent(omega, t, q);
 
+        #[cfg(debug)]
+        {
+            let check = mod_exponent(omega, n, q);
+            debug_assert!(
+                check == 1,
+                "omega({omega}) is not n^th root of unity: Expected 1 but is {check}",
+            );
+        }
+
         // We restrict n to be power of 2. Thus checking whether \omega is primitive
-        // n^th root of unity is a simple check: \omega^{n/2} != 1
+        // n^th root of unity is as simple as checking: \omega^{n/2} != 1
         if mod_exponent(omega, n >> 1, q) == 1 {
             continue;
         } else {

--- a/src/core_crypto/random.rs
+++ b/src/core_crypto/random.rs
@@ -157,6 +157,7 @@ where
             parameters.len()
         );
 
+        // TODO (Jay)
         // izip!(container.iter_rows_mut(), parameters.iter()).for_each(|(r,
         // qi)| {     izip!(
         //         r.as_mut().iter_mut(),

--- a/src/core_crypto/ring.rs
+++ b/src/core_crypto/ring.rs
@@ -414,10 +414,11 @@ mod tests {
         core_crypto::{
             modulus::{ModulusBackendConfig, NativeModulusBackend},
             prime::generate_primes_vec,
-            random::RandomUniformDist,
+            random::{DefaultU64SeededRandomGenerator, RandomUniformDist, DEFAULT_U64_SEEDED_RNG},
         },
         utils::{
-            convert::{TryConvertFrom, TryConvertFromParts}, mod_inverse, moduli_chain_to_biguint, test_utils::TestRng,
+            convert::{TryConvertFrom, TryConvertFromParts},
+            mod_inverse, moduli_chain_to_biguint,
         },
     };
 
@@ -470,9 +471,10 @@ mod tests {
             .collect_vec();
         let one_over_qi = q_chain.iter().map(|qi| 1f64 / *qi as f64).collect_vec();
 
-        let mut test = TestRng {};
+        let mut test = DefaultU64SeededRandomGenerator::new();
 
-        let poly_q_in = test.random_ring_poly(&q_chain, n);
+        let mut poly_q_in = <Vec<Vec<u64>> as Matrix>::zeros(q_chain.len(), n);
+        test.random_fill(&q_chain, &mut poly_q_in);
         let mut poly_p_out = Vec::<Vec<u64>>::zeros(p_chain.len(), n);
 
         fast_convert_p_over_q(
@@ -566,9 +568,11 @@ mod tests {
             })
             .collect_vec();
 
-        let mut test_rng = TestRng {};
+        let mut test_rng = DefaultU64SeededRandomGenerator::new();
 
-        let poly_q_in = test_rng.random_ring_poly(&q_chain, n);
+        let mut poly_q_in = <Vec<Vec<u64>> as Matrix>::zeros(q_chain.len(), n);
+        test_rng.random_fill(&q_chain, &mut poly_q_in);
+
         let mut poly_p_out = Vec::<Vec<u64>>::zeros(p_chain.len(), n);
 
         switch_crt_basis(
@@ -660,9 +664,11 @@ mod tests {
             );
         });
 
-        let mut test_rng = TestRng {};
+        let mut test_rng = DefaultU64SeededRandomGenerator::new();
 
-        let poly_q_in = test_rng.random_ring_poly(&q_chain, n);
+        let mut poly_q_in = <Vec<Vec<u64>> as Matrix>::zeros(q_chain.len(), n);
+        test_rng.random_fill(&q_chain, &mut poly_q_in);
+
         let mut poly_t_out = Vec::<Vec<u64>>::zeros(1, n);
 
         simple_scale_and_round(
@@ -772,11 +778,13 @@ mod tests {
             })
             .collect_vec();
 
-        let mut test_rng = TestRng {};
+        let mut test_rng = DefaultU64SeededRandomGenerator::new();
 
         // Random polynomial in QP
-        let poly0_q_part = test_rng.random_ring_poly(&q_chain, n);
-        let poly0_p_part = test_rng.random_ring_poly(&p_chain, n);
+        let mut poly0_q_part = <Vec<Vec<u64>> as Matrix>::zeros(q_chain.len(), n);
+        let mut poly0_p_part = <Vec<Vec<u64>> as Matrix>::zeros(p_chain.len(), n);
+        test_rng.random_fill(&q_chain, &mut poly0_q_part);
+        test_rng.random_fill(&p_chain, &mut poly0_p_part);
 
         let mut poly_out = Vec::<Vec<u64>>::zeros(q_chain.len(), n);
 

--- a/src/schemes/bfv/default_impl/entities.rs
+++ b/src/schemes/bfv/default_impl/entities.rs
@@ -63,7 +63,7 @@ impl BfvSecretKey {
 
 impl<P> Encryptor<[u64], BfvCiphertextScalarU64GenericStorage<P>> for BfvSecretKey
 where
-    P: TryConvertFrom <[i32], Parameters = [u64]> + MatrixMut<MatElement = u64>,
+    P: TryConvertFrom<[i32], Parameters = [u64]> + MatrixMut<MatElement = u64>,
     <P as Matrix>::R: RowMut,
 {
     fn encrypt(&self, message: &[u64]) -> BfvCiphertextScalarU64GenericStorage<P> {

--- a/src/schemes/bfv/default_impl/mod.rs
+++ b/src/schemes/bfv/default_impl/mod.rs
@@ -1,8 +1,7 @@
-use entities::BfvSecretKey;
-
 mod entities;
 
 pub type BfvCiphertext = entities::BfvCiphertextScalarU64GenericStorage<Vec<Vec<u64>>>;
+pub type BfvSecretKey = entities::BfvSecretKey;
 
 #[cfg(test)]
 mod tests {
@@ -40,7 +39,7 @@ mod tests {
 
     #[test]
     fn encryption_decryption_works() {
-        build_parameters(&[40, 40], 65537, 1 << 3);
+        build_parameters(&[50, 50], 65537, 1 << 3);
         let secret = BfvSecretKey::new();
 
         let m = vec![1];

--- a/src/schemes/bfv/ops.rs
+++ b/src/schemes/bfv/ops.rs
@@ -14,8 +14,8 @@ use crate::{
             RandomUniformDist,
         },
         ring::{
-            self, add_lazy_mut, add_mut, fast_convert_p_over_q, mul_lazy_mut, neg_mut,
-            scale_and_round, simple_scale_and_round, switch_crt_basis,
+            add_lazy_mut, add_mut, backward, fast_convert_p_over_q, foward_lazy, mul_lazy_mut,
+            neg_mut, scale_and_round, simple_scale_and_round, switch_crt_basis,
         },
     },
     keys::SecretKey,
@@ -25,32 +25,6 @@ use crate::{
     },
     utils::convert::TryConvertFrom,
 };
-
-fn foward_lazy<
-    Scalar: UnsignedInteger,
-    Poly: MatrixMut<MatElement = Scalar>,
-    N: Ntt<Scalar = Scalar>,
->(
-    p: &mut Poly,
-    ntt_ops: &[N],
-) where
-    <Poly as Matrix>::R: RowMut,
-{
-    izip!(p.iter_rows_mut(), ntt_ops.iter()).for_each(|(r, nttop)| nttop.forward_lazy(r.as_mut()));
-}
-
-fn backward<
-    Scalar: UnsignedInteger,
-    Poly: MatrixMut<MatElement = Scalar>,
-    N: Ntt<Scalar = Scalar>,
->(
-    p: &mut Poly,
-    ntt_ops: &[N],
-) where
-    <Poly as Matrix>::R: RowMut,
-{
-    izip!(p.iter_rows_mut(), ntt_ops.iter()).for_each(|(r, nttop)| nttop.backward(r.as_mut()));
-}
 
 pub fn generate_ternery_secret_with_hamming_weight<
     Scalar: Signed + Clone,

--- a/src/schemes/hybrid_ksk.rs
+++ b/src/schemes/hybrid_ksk.rs
@@ -1,0 +1,89 @@
+// key gen
+// key switch
+
+use std::thread::panicking;
+
+use itertools::{izip, Itertools};
+use num_bigint::BigUint;
+
+use crate::{
+    core_crypto::{
+        matrix::{Matrix, MatrixMut, RowMut},
+        modulus::ModulusVecBackend,
+        random::{InitWithSeed, RandomGaussianDist, RandomSeed, RandomUniformDist},
+    },
+    parameters::Parameters,
+};
+
+pub trait HybridKskKeyGenParameters: Parameters {
+    type ModOp: ModulusVecBackend<Self::Scalar>;
+
+    fn dnum(&self) -> usize;
+    fn ring_size(&self) -> usize;
+    fn specialp_moduli_chain(&self) -> &[Self::Scalar];
+    fn primes_at_level(&self) -> usize;
+
+    fn modq_ops_at_level(&self, level: usize) -> &[Self::ModOp];
+    fn modspecialp_ops_at_level(&self, level: usize) -> &[Self::ModOp];
+    fn q_moduli_chain_at_level(&self, level: usize) -> &[Self::Scalar];
+    fn specialp_moduli_chain_at_level(&self, level: usize) -> &[Self::Scalar];
+    fn big_specialp(&self, level: usize) -> BigUint;
+    fn big_qjs_at_level(&self, level: usize) -> &[BigUint];
+    fn gammak_modqi_at_level(&self, level: usize) -> &[Vec<Self::Scalar>];
+    fn gammak_modspecialpj_at_level(&self, level: usize) -> &[Vec<Self::Scalar>];
+    fn alpha_at_level(&self, level: usize) -> usize;
+}
+
+fn generate_key<
+    P: HybridKskKeyGenParameters,
+    M: Matrix<MatElement = P::Scalar> + MatrixMut + Clone,
+    R: RandomSeed + RandomGaussianDist<M>,
+    NR: InitWithSeed<Seed = R::Seed> + RandomUniformDist<M>,
+>(
+    params: P,
+    level: usize,
+    p: M,
+    rng: &mut R,
+) where
+    <M as Matrix>::R: RowMut,
+{
+    debug_assert!(p.dimension() == (params.primes_at_level(), params.ring_size()));
+
+    let dnum = params.dnum();
+
+    let alpha = (dnum as f64 / (level as f64 + 1.0)).ceil() as usize;
+    let q_moduli_chain = params.q_moduli_chain_at_level(level);
+    let specialp_moduli_chain = params.specialp_moduli_chain();
+
+    let big_specialp = params.big_specialp(level);
+    let ring_size = params.ring_size();
+
+    // q_moduli_chain.iter().chunks(dnum)
+    let seed = rng.random_seed();
+
+    let gammak_modqi_at_level = params.gammak_modqi_at_level(level);
+    let gammak_modspecialpj_at_level = params.gammak_modspecialpj_at_level(level);
+    let modq_ops = params.modq_ops_at_level(level);
+    let modspecialp_ops = params.modspecialp_ops_at_level(level);
+    let mut prng = NR::init_with_seed(seed);
+    for k in 0..alpha {
+        let mut p_clone = p.clone();
+
+        // part Q
+        // let gammak = &gammak_modqi_at_level[k];
+        // let mut ak_partq =
+        //     RandomUniformDist::random_ring_poly(&mut prng, q_moduli_chain,
+        // ring_size); let mut ek_partq =
+        //     RandomGaussianDist::random_ring_poly(&mut rng, q_moduli_chain,
+        // ring_size);
+
+        // izip!(modq_ops.iter(), gammak.iter(),
+        // p_clone.iter_rows_mut()).for_each(     |(modqi, gki, ak_modqi)| {
+        //         modqi.scalar_mul_mod_vec(ak_modqi.as_mut(), *gki);
+        //     },
+        // );
+
+        // part specialP
+    }
+}
+fn keyswitch() {}

--- a/src/schemes/hybrid_ksk.rs
+++ b/src/schemes/hybrid_ksk.rs
@@ -9,81 +9,163 @@ use num_bigint::BigUint;
 use crate::{
     core_crypto::{
         matrix::{Matrix, MatrixMut, RowMut},
-        modulus::ModulusVecBackend,
+        modulus::{ModulusArithmeticBackend, ModulusVecBackend},
+        ntt::Ntt,
         random::{InitWithSeed, RandomGaussianDist, RandomSeed, RandomUniformDist},
+        ring::{add_lazy_mut, foward_lazy, mul_lazy_mut},
     },
+    keys::SecretKey,
     parameters::Parameters,
+    utils::convert::TryConvertFrom,
 };
 
 pub trait HybridKskKeyGenParameters: Parameters {
     type ModOp: ModulusVecBackend<Self::Scalar>;
+    type NttOp: Ntt<Scalar = Self::Scalar>;
 
     fn dnum(&self) -> usize;
     fn ring_size(&self) -> usize;
     fn specialp_moduli_chain(&self) -> &[Self::Scalar];
     fn primes_at_level(&self) -> usize;
 
-    fn modq_ops_at_level(&self, level: usize) -> &[Self::ModOp];
-    fn modspecialp_ops_at_level(&self, level: usize) -> &[Self::ModOp];
+    fn q_modops_at_level(&self, level: usize) -> &[Self::ModOp];
+    fn specialp_modops_at_level(&self, level: usize) -> &[Self::ModOp];
+
+    fn q_nttops_at_level(&self, level: usize) -> &[Self::NttOp];
+    fn specialp_nttops_at_level(&self, level: usize) -> &[Self::NttOp];
+
     fn q_moduli_chain_at_level(&self, level: usize) -> &[Self::Scalar];
     fn specialp_moduli_chain_at_level(&self, level: usize) -> &[Self::Scalar];
+
     fn big_specialp(&self, level: usize) -> BigUint;
     fn big_qjs_at_level(&self, level: usize) -> &[BigUint];
+
     fn gammak_modqi_at_level(&self, level: usize) -> &[Vec<Self::Scalar>];
-    fn gammak_modspecialpj_at_level(&self, level: usize) -> &[Vec<Self::Scalar>];
     fn alpha_at_level(&self, level: usize) -> usize;
 }
 
 fn generate_key<
     P: HybridKskKeyGenParameters,
-    M: Matrix<MatElement = P::Scalar> + MatrixMut + Clone,
-    R: RandomSeed + RandomGaussianDist<M>,
-    NR: InitWithSeed<Seed = R::Seed> + RandomUniformDist<M>,
+    M: Matrix<MatElement = P::Scalar> + MatrixMut,
+    R: RandomSeed + RandomGaussianDist<[P::Scalar], Parameters = P::Scalar>,
+    NR: InitWithSeed<Seed = R::Seed> + RandomUniformDist<[P::Scalar], Parameters = P::Scalar>,
+    S: SecretKey<Scalar = i32>,
 >(
     params: P,
     level: usize,
     p: M,
+    secret: &S,
+    ksk_polys: &mut [M],
     rng: &mut R,
 ) where
-    <M as Matrix>::R: RowMut,
+    <M as Matrix>::R: RowMut + Clone,
+    M: TryConvertFrom<[i32], Parameters = [P::Scalar]>,
 {
-    debug_assert!(p.dimension() == (params.primes_at_level(), params.ring_size()));
-
     let dnum = params.dnum();
-
     let alpha = (dnum as f64 / (level as f64 + 1.0)).ceil() as usize;
+
+    debug_assert!(p.dimension() == (params.primes_at_level(), params.ring_size()));
+    debug_assert!(
+        ksk_polys.len() == alpha * 2,
+        "KSK polynomials supplied {} != expected polynomials alpha*2 {}",
+        ksk_polys.len(),
+        alpha * 2
+    );
+
     let q_moduli_chain = params.q_moduli_chain_at_level(level);
     let specialp_moduli_chain = params.specialp_moduli_chain();
 
-    let big_specialp = params.big_specialp(level);
     let ring_size = params.ring_size();
 
     // q_moduli_chain.iter().chunks(dnum)
     let seed = rng.random_seed();
 
     let gammak_modqi_at_level = params.gammak_modqi_at_level(level);
-    let gammak_modspecialpj_at_level = params.gammak_modspecialpj_at_level(level);
-    let modq_ops = params.modq_ops_at_level(level);
-    let modspecialp_ops = params.modspecialp_ops_at_level(level);
+    let q_modops = params.q_modops_at_level(level);
+    let specialp_modops = params.specialp_modops_at_level(level);
     let mut prng = NR::init_with_seed(seed);
-    for k in 0..alpha {
-        let mut p_clone = p.clone();
+
+    let q_nttops = params.q_nttops_at_level(level);
+    let specialp_nttops = params.specialp_nttops_at_level(level);
+
+    let mut s_partq = M::try_convert_from(secret.values(), q_moduli_chain);
+    let mut s_partspecialp = M::try_convert_from(secret.values(), specialp_moduli_chain);
+    foward_lazy(&mut s_partq, q_nttops);
+    foward_lazy(&mut s_partspecialp, specialp_nttops);
+
+    let q_size = q_moduli_chain.len();
+    let specialp_size = specialp_moduli_chain.len();
+
+    for (k, ck) in izip!(0..alpha, ksk_polys.chunks_exact_mut(2)) {
+        let gammak = &gammak_modqi_at_level[k];
+
+        let (c0_k, c1_k) = ck.split_at_mut(1);
+        let c0_k = &mut c0_k[0];
+        let c1_k = &mut c1_k[0];
+
+        debug_assert!(c0_k.dimension() == (q_size + specialp_size, ring_size));
+        debug_assert!(c1_k.dimension() == (q_size + specialp_size, ring_size));
 
         // part Q
-        // let gammak = &gammak_modqi_at_level[k];
-        // let mut ak_partq =
-        //     RandomUniformDist::random_ring_poly(&mut prng, q_moduli_chain,
-        // ring_size); let mut ek_partq =
-        //     RandomGaussianDist::random_ring_poly(&mut rng, q_moduli_chain,
-        // ring_size);
+        izip!(
+            gammak.iter(),
+            q_moduli_chain.iter(),
+            q_modops.iter(),
+            q_nttops.iter(),
+            p.iter_rows(),
+            c0_k.iter_rows_mut().take(q_size),
+            c1_k.iter_rows_mut().take(q_size),
+            s_partq.iter_rows()
+        )
+        .for_each(
+            |(gammak_modqi, qi, qi_modop, qi_nttop, p_modqi, c0k_modqi, c1k_modqi, s_modqi)| {
+                // Assume c_{1,k} is sampled in evaluation form
+                RandomUniformDist::random_fill(&mut prng, qi, c1k_modqi.as_mut());
 
-        // izip!(modq_ops.iter(), gammak.iter(),
-        // p_clone.iter_rows_mut()).for_each(     |(modqi, gki, ak_modqi)| {
-        //         modqi.scalar_mul_mod_vec(ak_modqi.as_mut(), *gki);
-        //     },
-        // );
+                // c1_k * s \mod qi
+                let mut c1k_s = c1k_modqi.clone();
+                qi_modop.mul_lazy_mod_vec(c1k_s.as_mut(), s_modqi.as_ref());
+
+                // e \mod qi
+                RandomGaussianDist::random_fill(rng, qi, c0k_modqi.as_mut());
+                qi_nttop.forward_lazy(c0k_modqi.as_mut());
+
+                // e + c1_k * s \mod qi
+                qi_modop.add_lazy_mod_vec(c0k_modqi.as_mut(), c1k_s.as_ref());
+
+                // gamma_k * p \mod qi
+                let mut p_modqi_clone = p_modqi.clone();
+                qi_modop.scalar_mul_mod_vec(p_modqi_clone.as_mut(), *gammak_modqi);
+
+                // e + c1_k * s + gamma_k * p \mod qi
+                qi_modop.add_lazy_mod_vec(c0k_modqi.as_mut(), p_modqi_clone.as_ref());
+            },
+        );
 
         // part specialP
+        izip!(
+            specialp_moduli_chain.iter(),
+            specialp_modops.iter(),
+            specialp_nttops.iter(),
+            c0_k.iter_rows_mut().skip(q_size),
+            c1_k.iter_rows_mut().skip(q_size),
+            s_partspecialp.iter_rows()
+        )
+        .for_each(|(pj, pj_modop, pj_nttop, c0k_modpj, c1k_modpj, s_modpj)| {
+            // Assume c_{1, k} is sampled in evaluation form
+            RandomUniformDist::random_fill(&mut prng, pj, c1k_modpj.as_mut());
+
+            // c1_k * s \mod pj
+            let mut c1k_s = c1k_modpj.clone();
+            pj_modop.mul_lazy_mod_vec(c1k_s.as_mut(), s_modpj.as_ref());
+
+            // e \mod pj
+            RandomGaussianDist::random_fill(rng, pj, c0k_modpj.as_mut());
+            pj_nttop.forward_lazy(c0k_modpj.as_mut());
+
+            // e + c1_k * s \mod pj
+            pj_modop.add_lazy_mod_vec(c0k_modpj.as_mut(), c1k_s.as_ref());
+        });
     }
 }
 fn keyswitch() {}

--- a/src/schemes/hybrid_ksk.rs
+++ b/src/schemes/hybrid_ksk.rs
@@ -5,14 +5,18 @@ use std::thread::panicking;
 
 use itertools::{izip, Itertools};
 use num_bigint::BigUint;
+use num_traits::{AsPrimitive, PrimInt, Unsigned};
 
 use crate::{
     core_crypto::{
         matrix::{Matrix, MatrixMut, RowMut},
-        modulus::{ModulusArithmeticBackend, ModulusVecBackend},
+        modulus::{BarrettBackend, ModulusVecBackend, MontgomeryBackend, MontgomeryScalar},
         ntt::Ntt,
+        num::UnsignedInteger,
         random::{InitWithSeed, RandomGaussianDist, RandomSeed, RandomUniformDist},
-        ring::{add_lazy_mut, foward_lazy, mul_lazy_mut},
+        ring::{
+            self, approximate_mod_down, approximate_switch_crt_basis, backward, foward, foward_lazy,
+        },
     },
     keys::SecretKey,
     parameters::Parameters,
@@ -44,6 +48,48 @@ pub trait HybridKskKeyGenParameters: Parameters {
     fn alpha_at_level(&self, level: usize) -> usize;
 }
 
+pub trait HybridKskRuntimeParameters: Parameters
+where
+    // TODO(Jay): [Remove]`num_traits::AsPrimitive<u128>
+    // + num_traits::PrimInt,` are a consquenece of
+    // BarrettBackend trait. Check issue #12
+    Self::Scalar: num_traits::AsPrimitive<u128> + num_traits::PrimInt,
+    u128: AsPrimitive<Self::Scalar>,
+{
+    type ModOp: ModulusVecBackend<Self::Scalar>
+        + BarrettBackend<Self::Scalar, u128>
+        + MontgomeryBackend<Self::Scalar, u128>;
+    type NttOp: Ntt<Scalar = Self::Scalar>;
+
+    fn dnum(&self) -> usize;
+
+    fn q_modops_at_level(&self, level: usize) -> &[Self::ModOp];
+    fn specialp_modops_at_level(&self, level: usize) -> &[Self::ModOp];
+
+    fn q_nttops_at_level(&self, level: usize) -> &[Self::NttOp];
+    fn specialp_nttops_at_level(&self, level: usize) -> &[Self::NttOp];
+
+    fn q_moduli_chain_at_level(&self, level: usize) -> &[Self::Scalar];
+    fn specialp_moduli_chain_at_level(&self, level: usize) -> &[Self::Scalar];
+
+    fn specialp_over_specialpj_modspecialpj_at_level(&self, level: usize) -> &[Self::Scalar];
+    fn specialp_over_specialpj_per_modqi_at_level(
+        &self,
+        level: usize,
+    ) -> &[Vec<MontgomeryScalar<Self::Scalar>>];
+    fn specialp_inv_modqi_at_level(&self, level: usize) -> &[Self::Scalar];
+
+    fn qj_over_qji_inv_modqji_level(&self, level: usize) -> &[Vec<Self::Scalar>];
+    fn qj_over_qji_per_modqi_at_level(
+        &self,
+        level: usize,
+    ) -> &[Vec<Vec<MontgomeryScalar<Self::Scalar>>>];
+    fn qj_over_qji_per_modspecialpj_at_level(
+        &self,
+        level: usize,
+    ) -> &[Vec<Vec<MontgomeryScalar<Self::Scalar>>>];
+}
+
 fn generate_key<
     P: HybridKskKeyGenParameters,
     M: Matrix<MatElement = P::Scalar> + MatrixMut,
@@ -51,7 +97,7 @@ fn generate_key<
     NR: InitWithSeed<Seed = R::Seed> + RandomUniformDist<[P::Scalar], Parameters = P::Scalar>,
     S: SecretKey<Scalar = i32>,
 >(
-    params: P,
+    params: &P,
     level: usize,
     p: M,
     secret: &S,
@@ -77,13 +123,13 @@ fn generate_key<
 
     let ring_size = params.ring_size();
 
-    // q_moduli_chain.iter().chunks(dnum)
     let seed = rng.random_seed();
+    let mut prng = NR::init_with_seed(seed);
 
     let gammak_modqi_at_level = params.gammak_modqi_at_level(level);
+
     let q_modops = params.q_modops_at_level(level);
     let specialp_modops = params.specialp_modops_at_level(level);
-    let mut prng = NR::init_with_seed(seed);
 
     let q_nttops = params.q_nttops_at_level(level);
     let specialp_nttops = params.specialp_nttops_at_level(level);
@@ -168,4 +214,283 @@ fn generate_key<
         });
     }
 }
-fn keyswitch() {}
+
+fn keyswitch<
+    M: Matrix,
+    MMut: MatrixMut<MatElement = M::MatElement> + Clone,
+    P: HybridKskRuntimeParameters<Scalar = M::MatElement>,
+>(
+    x: M,
+    c0_out: &mut MMut,
+    c1_out: &mut MMut,
+    ksk_polys: &[M],
+    params: &P,
+) where
+    <MMut as Matrix>::R: RowMut,
+    M::MatElement: UnsignedInteger,
+    // TODO(Jay): [Remove] these additional bounds are a consquenece of
+    // BarrettBackend & Montgomery trait. Check issue #12
+    <P as Parameters>::Scalar: AsPrimitive<u128> + PrimInt,
+    u128: AsPrimitive<<P as Parameters>::Scalar>,
+{
+    let dnum = params.dnum();
+
+    let level = 0;
+    let q_moduli_chain = params.q_moduli_chain_at_level(level);
+    let specialp_moduli_chain = params.specialp_moduli_chain_at_level(level);
+
+    let q_nttops = params.q_nttops_at_level(level);
+    let specialp_nttops = params.specialp_nttops_at_level(level);
+
+    let q_modops = params.q_modops_at_level(level);
+    let specialp_modops = params.specialp_modops_at_level(level);
+
+    let q_size = q_moduli_chain.len();
+    let specialp_size = specialp_moduli_chain.len();
+    let ring_size = 0;
+
+    let mut k = 0;
+    let mut c0_sum_subbasisq = MMut::zeros(q_size, ring_size);
+    let mut c1_sum_subbasisq = MMut::zeros(q_size, ring_size);
+    let mut c0_sum_subbasisspecialp = MMut::zeros(q_size, ring_size);
+    let mut c1_sum_subbasisspecialp = MMut::zeros(q_size, ring_size);
+
+    let qj_over_qji_inv_modqji_all_k = params.qj_over_qji_inv_modqji_level(level);
+    let qj_over_qji_per_modqi_all_k = params.qj_over_qji_per_modqi_at_level(level);
+    let qj_over_qji_per_modspecialpj_all_k = params.qj_over_qji_per_modspecialpj_at_level(level);
+    for i in (0..q_size).step_by(dnum) {
+        let start = i;
+        let end = std::cmp::min(i + dnum, q_size); // end is excluded from range
+
+        // let qj_moduli_chain = &q_moduli_chain[start..end];
+        // let qj_modops = &q_modops[start..end];
+
+        let qj_over_qji_inv_modqji = &qj_over_qji_inv_modqji_all_k[k];
+        debug_assert!(
+            qj_over_qji_inv_modqji.len() == end - start,
+            "Q_j/q_[{k},i]^[-1] switch precomputes are incorrect: Expected length {} but got {}",
+            end - start,
+            qj_over_qji_inv_modqji.len()
+        );
+
+        let qj_over_qji_per_modqi = &qj_over_qji_per_modqi_all_k[k];
+        debug_assert!(
+            qj_over_qji_per_modqi.len() == q_size - (end - start),
+            "Q_j/q_[{k},i] mod q_i switch precomputes are incorrect: Expected length {} but got {}",
+            q_size - (end - start),
+            qj_over_qji_per_modqi.len()
+        );
+
+        let qj_over_qji_per_modspecialpj = &qj_over_qji_per_modspecialpj_all_k[k];
+        debug_assert!(
+            qj_over_qji_per_modspecialpj.len() == specialp_size,
+            "Q_j/q_[{k},i] mod specialpj switch precomputes are incorrect: Expected length {} but got {}",
+            specialp_size,
+            qj_over_qji_per_modspecialpj.len()
+        );
+
+        // Switch basis x \in Qj from Qj to QP_s
+        let mut q_till_start = MMut::zeros(start, ring_size);
+        let mut q_from_end = MMut::zeros(q_size - end, ring_size);
+        let mut specialp_all = MMut::zeros(specialp_size, ring_size);
+        for ri in 0..ring_size {
+            let mut q_values = Vec::with_capacity(end - start);
+            for j in start..end {
+                q_values.push(
+                    q_modops[j].mul_mod_fast(*x.get_element(j, ri), qj_over_qji_inv_modqji[j]),
+                );
+            }
+
+            // q_0..q_{start-1}
+            for (index, (qi, modqi, qj_over_qji_modqi)) in izip!(
+                &q_moduli_chain[..start],
+                &q_modops[..start],
+                &qj_over_qji_per_modqi[..start]
+            )
+            .enumerate()
+            {
+                // map q_values to mont space
+                let q_in_mont_space = q_values
+                    .iter()
+                    .map(|v| modqi.normal_to_mont_space(*v))
+                    .collect_vec();
+
+                let tmp = modqi.mont_fma(&q_in_mont_space, &qj_over_qji_modqi);
+                let tmp = modqi.mont_to_normal(tmp);
+                q_till_start.set(index, ri, tmp)
+            }
+
+            // q_{end}..q_l
+            for (index, (qi, modqi, qj_over_qji_modqi)) in izip!(
+                &q_moduli_chain[end..],
+                &q_modops[end..start],
+                &qj_over_qji_per_modqi[start..]
+            )
+            .enumerate()
+            {
+                // map q_values to mont space
+                let q_in_mont_space = q_values
+                    .iter()
+                    .map(|v| modqi.normal_to_mont_space(*v))
+                    .collect_vec();
+
+                let tmp = modqi.mont_fma(&q_in_mont_space, &qj_over_qji_modqi);
+                let tmp = modqi.mont_to_normal(tmp);
+                q_from_end.set(end + index, ri, tmp)
+            }
+
+            // p_0..p_l
+            for (index, (pj, modpj, qj_over_qji_modpj)) in izip!(
+                specialp_moduli_chain,
+                specialp_modops,
+                qj_over_qji_per_modspecialpj
+            )
+            .enumerate()
+            {
+                // map q_values to mont space
+                let q_in_mont_space = q_values
+                    .iter()
+                    .map(|v| modpj.normal_to_mont_space(*v))
+                    .collect_vec();
+
+                let tmp = modpj.mont_fma(&q_in_mont_space, &qj_over_qji_modpj);
+                let tmp = modpj.mont_to_normal(tmp);
+                specialp_all.set(index, ri, tmp);
+            }
+        }
+
+        // Multiply x \in QP_s with corresponding ksk ciphertext
+
+        // q_0..q_{start-1}
+        foward_lazy(&mut q_till_start, &q_nttops[..start]);
+        let mut q_till_start_c0 = q_till_start.clone();
+        let mut q_till_start_c1 = q_till_start;
+        for (modqi, x_qi_c0, x_qi_c1, c0_k_qi, c1_k_qi, c0_sum_qi, c1_sum_qi) in izip!(
+            q_modops[..start].iter(),
+            q_till_start_c0.iter_rows_mut(),
+            q_till_start_c1.iter_rows_mut(),
+            ksk_polys[2 * k].iter_rows().take(start),
+            ksk_polys[2 * k + 1].iter_rows().take(start),
+            c0_sum_subbasisq.iter_rows_mut().take(start),
+            c1_sum_subbasisq.iter_rows_mut().take(start)
+        ) {
+            modqi.mul_lazy_mod_vec(x_qi_c0.as_mut(), c0_k_qi.as_ref());
+            modqi.mul_lazy_mod_vec(x_qi_c1.as_mut(), c1_k_qi.as_ref());
+
+            modqi.add_lazy_mod_vec(c0_sum_qi.as_mut(), x_qi_c0.as_ref());
+            modqi.add_lazy_mod_vec(c1_sum_qi.as_mut(), x_qi_c1.as_ref());
+        }
+
+        // q_{start}..q_{end-1}
+        let mut x_partqj = {
+            // TODO (Jay): Require a better way to copy elements of sub-matrix
+            let mut tmp = MMut::zeros(end - start, ring_size);
+            izip!(
+                tmp.iter_rows_mut(),
+                x.iter_rows().skip(start).take(end - start)
+            )
+            .for_each(|(to, from)| to.as_mut().copy_from_slice(from.as_ref()));
+            tmp
+        };
+        foward_lazy(&mut x_partqj, &q_nttops[start..end]);
+        let mut x_partqj_c0 = x_partqj.clone();
+        let mut x_partqj_c1 = x_partqj;
+        for (modqi, x_qi_c0, x_qi_c1, c0_k_qi, c1_k_qi, c0_sum_qi, c1_sum_qi) in izip!(
+            q_modops[..start].iter(),
+            x_partqj_c0.iter_rows_mut(),
+            x_partqj_c1.iter_rows_mut(),
+            ksk_polys[2 * k].iter_rows().skip(start),
+            ksk_polys[2 * k + 1].iter_rows().skip(start),
+            c0_sum_subbasisq.iter_rows_mut().skip(start),
+            c1_sum_subbasisq.iter_rows_mut().skip(start)
+        ) {
+            modqi.mul_lazy_mod_vec(x_qi_c0.as_mut(), c0_k_qi.as_ref());
+            modqi.mul_lazy_mod_vec(x_qi_c1.as_mut(), c1_k_qi.as_ref());
+
+            modqi.add_lazy_mod_vec(c0_sum_qi.as_mut(), x_qi_c0.as_ref());
+            modqi.add_lazy_mod_vec(c1_sum_qi.as_mut(), x_qi_c1.as_ref());
+        }
+
+        // q_end..q_{size-1}
+        foward_lazy(&mut q_from_end, &q_nttops[end..]);
+        let mut q_from_end_c0 = q_from_end.clone();
+        let mut q_from_end_c1 = q_from_end;
+        for (modqi, x_qi_c0, x_qi_c1, c0_k_qi, c1_k_qi, c0_sum_qi, c1_sum_qi) in izip!(
+            q_modops[..start].iter(),
+            q_from_end_c0.iter_rows_mut(),
+            q_from_end_c1.iter_rows_mut(),
+            ksk_polys[2 * k].iter_rows().skip(end),
+            ksk_polys[2 * k + 1].iter_rows().skip(end),
+            c0_sum_subbasisq.iter_rows_mut().skip(start),
+            c1_sum_subbasisq.iter_rows_mut().skip(start)
+        ) {
+            modqi.mul_lazy_mod_vec(x_qi_c0.as_mut(), c0_k_qi.as_ref());
+            modqi.mul_lazy_mod_vec(x_qi_c1.as_mut(), c1_k_qi.as_ref());
+
+            modqi.add_lazy_mod_vec(c0_sum_qi.as_mut(), x_qi_c0.as_ref());
+            modqi.add_lazy_mod_vec(c1_sum_qi.as_mut(), x_qi_c1.as_ref());
+        }
+
+        // p_0..p{size-1}
+        foward_lazy(&mut specialp_all, specialp_nttops);
+        let mut specialp_all_c0 = specialp_all.clone();
+        let mut specialp_all_c1 = specialp_all;
+        for (modpj, x_pj_c0, x_pj_c1, c0_k_pj, c1_k_pj, c0_sum_pj, c1_sum_pj) in izip!(
+            specialp_modops.iter(),
+            specialp_all_c0.iter_rows_mut(),
+            specialp_all_c1.iter_rows_mut(),
+            ksk_polys[2 * k].iter_rows().skip(q_size),
+            ksk_polys[2 * k + 1].iter_rows().skip(q_size),
+            c0_sum_subbasisspecialp.iter_rows_mut(),
+            c1_sum_subbasisspecialp.iter_rows_mut()
+        ) {
+            modpj.mul_lazy_mod_vec(x_pj_c0.as_mut(), c0_k_pj.as_ref());
+            modpj.mul_lazy_mod_vec(x_pj_c1.as_mut(), c1_k_pj.as_ref());
+
+            modpj.add_lazy_mod_vec(c0_sum_pj.as_mut(), x_pj_c0.as_ref());
+            modpj.add_lazy_mod_vec(c1_sum_pj.as_mut(), x_pj_c1.as_ref());
+        }
+
+        k += 1;
+    }
+
+    // Change representation of only subbasis P_s to Coefficient for approximate mod
+    // down
+    backward(&mut c0_sum_subbasisspecialp, specialp_nttops);
+    backward(&mut c1_sum_subbasisspecialp, specialp_nttops);
+
+    // Approximate Mod Down: v \in QP_s => (1/P)v \in Q
+    let specialp_over_specialpj_modspecialpj =
+        params.specialp_over_specialpj_modspecialpj_at_level(level);
+    let specialp_over_specialpj_per_modqi =
+        params.specialp_over_specialpj_per_modqi_at_level(level);
+    let specialp_inv_modqi = params.specialp_inv_modqi_at_level(level);
+    approximate_mod_down(
+        c0_out,
+        &c0_sum_subbasisq,
+        &c0_sum_subbasisspecialp,
+        specialp_over_specialpj_modspecialpj,
+        specialp_over_specialpj_per_modqi,
+        specialp_inv_modqi,
+        q_modops,
+        specialp_modops,
+        specialp_nttops,
+        ring_size,
+        q_size,
+        specialp_size,
+    );
+    approximate_mod_down(
+        c1_out,
+        &c0_sum_subbasisq,
+        &c0_sum_subbasisspecialp,
+        specialp_over_specialpj_modspecialpj,
+        specialp_over_specialpj_per_modqi,
+        specialp_inv_modqi,
+        q_modops,
+        specialp_modops,
+        specialp_nttops,
+        ring_size,
+        q_size,
+        specialp_size,
+    );
+}

--- a/src/schemes/hybrid_ksk/mod.rs
+++ b/src/schemes/hybrid_ksk/mod.rs
@@ -1,0 +1,581 @@
+use itertools::Itertools;
+use num_bigint::BigUint;
+use num_traits::{FromPrimitive, One, ToPrimitive};
+
+use crate::{
+    core_crypto::{
+        modulus::{
+            ModulusBackendConfig, MontgomeryBackend, MontgomeryScalar, NativeModulusBackend,
+        },
+        ntt::{NativeNTTBackend, NttConfig},
+    },
+    parameters::Parameters,
+    utils::mod_inverse_big_unit,
+};
+
+use self::ops::{HybridKskKeyGenParameters, HybridKskRuntimeParameters};
+
+pub(crate) mod ops;
+
+struct HybridKskParametersScalarU64 {
+    q_modops: Vec<NativeModulusBackend>,
+    specialp_modops: Vec<NativeModulusBackend>,
+
+    q_nttops: Vec<NativeNTTBackend>,
+    specialp_nttops: Vec<NativeNTTBackend>,
+
+    q_moduli_chain: Vec<u64>,
+    specialp_moduli_chain: Vec<u64>,
+
+    // Key generation parametrs //
+    gammak_modqi_at_level: Vec<Vec<Vec<u64>>>,
+
+    // Ksk runtime parameters //
+    // To switch x \in Qj to x \in QP_s //
+    qj_over_qji_inv_modqji_all_k_at_level: Vec<Vec<Vec<u64>>>,
+    qj_over_qji_per_modqi_all_k_at_level: Vec<Vec<Vec<Vec<MontgomeryScalar<u64>>>>>,
+    qj_over_qji_per_modspecialpj_all_k_at_level: Vec<Vec<Vec<Vec<MontgomeryScalar<u64>>>>>,
+    // To scale by 1/P_s and switch v \in QP_s to (1/P)v \in Q //
+    specialp_over_specialpj_inv_modspecialpj: Vec<u64>,
+    specialp_over_specialpj_per_modqi: Vec<Vec<MontgomeryScalar<u64>>>,
+    specialp_inv_modqi: Vec<u64>,
+
+    // Other //
+    dnum: usize,
+    q_moduli_chain_len: usize,
+    ring_size: usize,
+    alpha_at_level: Vec<usize>,
+}
+
+impl HybridKskParametersScalarU64 {
+    pub fn new(
+        q_moduli_chain: &[u64],
+        specialp_moduli_chain: &[u64],
+        dnum: usize,
+        ring_size: usize,
+    ) -> Self {
+        // In general if q moduli chain for the second last level will be smaller than
+        // bit size of special p. And it is possible to improve efficiency for hybrid
+        // keyswitching by dropping 1-2 primes from special p moduli chain. But we don't
+        // handle for this case. It should instead be handled at parameter generation
+        // phase
+
+        let mut big_specialp = BigUint::one();
+        for pj in specialp_moduli_chain.iter() {
+            big_specialp *= *pj;
+        }
+
+        let mut gammak_modqi_at_level = vec![];
+        let mut alpha_at_level = vec![];
+        let mut qj_over_qji_inv_modqji_all_k_at_level = vec![];
+        let mut qj_over_qji_per_modqi_all_k_at_level = vec![];
+        let mut qj_over_qji_per_modspecialpj_all_k_at_level = vec![];
+        for lvl in 0..(q_moduli_chain.len()) {
+            let q_moduli_chain_at_level = &q_moduli_chain[..q_moduli_chain.len() - lvl];
+
+            let mut big_q = BigUint::one();
+            for qi in q_moduli_chain_at_level.iter() {
+                big_q *= *qi;
+            }
+            let primes_count_at_lvl = q_moduli_chain_at_level.len();
+
+            let mut gammak_modqi = vec![];
+            let mut qj_over_qji_inv_modqji_all_k = vec![];
+            let mut qj_over_qji_per_modqi_all_k = vec![];
+            let mut qj_over_qji_per_modspecialpj_all_k = vec![];
+            for i in (0..primes_count_at_lvl).step_by(dnum) {
+                let start = i;
+                let end = std::cmp::min(i + dnum, primes_count_at_lvl);
+
+                let mut big_qj = BigUint::one();
+                for j in (start..end) {
+                    big_qj *= q_moduli_chain_at_level[j];
+                }
+
+                // gamma = P * Q/Qj^{-1} * Q/Qj
+                let q_over_qj = &big_q / &big_qj;
+                let gamma = &big_specialp * mod_inverse_big_unit(&q_over_qj, &big_qj) * &q_over_qj;
+
+                let mut tmp = vec![];
+                for qi in q_moduli_chain_at_level.iter() {
+                    tmp.push((&gamma % *qi).to_u64().unwrap());
+                }
+                gammak_modqi.push(tmp);
+
+                // Ksk runtime parameters //
+
+                // Parameters to switch x \in Qj to QP_s//
+                let mut qj_over_qji_inv_modqji = vec![];
+                let mut qj_over_qji_vec = vec![];
+                for j in (start..end) {
+                    let qji = q_moduli_chain_at_level[j];
+                    let qj_over_qji = &big_qj / qji;
+
+                    qj_over_qji_inv_modqji.push(
+                        mod_inverse_big_unit(&qj_over_qji, &BigUint::from_u64(qji).unwrap())
+                            .to_u64()
+                            .unwrap(),
+                    );
+
+                    qj_over_qji_vec.push(qj_over_qji);
+                }
+
+                let mut qj_over_qji_per_modqi = vec![];
+                // q_0..q_{start-1}
+                for qi in q_moduli_chain_at_level[..start].iter() {
+                    // TODO (Jay): Move montgomery arithemtic out of the trait as an independent
+                    // function. Then remove this and call the function directly
+                    let modqi = NativeModulusBackend::initialise(*qi);
+                    qj_over_qji_per_modqi.push(
+                        qj_over_qji_vec
+                            .iter()
+                            .map(|v| modqi.normal_to_mont_space((v % qi).to_u64().unwrap()))
+                            .collect_vec(),
+                    );
+                }
+                // q_end..q_{size-1}
+                for qi in q_moduli_chain_at_level[end..].iter() {
+                    // TODO (Jay): Move montgomery arithemtic out of the trait as an independent
+                    // function. Then remove this and call the function directly
+                    let modqi = NativeModulusBackend::initialise(*qi);
+                    qj_over_qji_per_modqi.push(
+                        qj_over_qji_vec
+                            .iter()
+                            .map(|v| modqi.normal_to_mont_space((v % qi).to_u64().unwrap()))
+                            .collect_vec(),
+                    );
+                }
+                let mut qj_over_qji_per_modspecialpj = vec![];
+                for pj in specialp_moduli_chain.iter() {
+                    let modpj = NativeModulusBackend::initialise(*pj);
+                    qj_over_qji_per_modspecialpj.push(
+                        qj_over_qji_vec
+                            .iter()
+                            .map(|v| modpj.normal_to_mont_space((v % pj).to_u64().unwrap()))
+                            .collect_vec(),
+                    );
+                }
+
+                qj_over_qji_inv_modqji_all_k.push(qj_over_qji_inv_modqji);
+                qj_over_qji_per_modqi_all_k.push(qj_over_qji_per_modqi);
+                qj_over_qji_per_modspecialpj_all_k.push(qj_over_qji_per_modspecialpj);
+            }
+
+            gammak_modqi_at_level.push(gammak_modqi);
+            qj_over_qji_inv_modqji_all_k_at_level.push(qj_over_qji_inv_modqji_all_k);
+            qj_over_qji_per_modqi_all_k_at_level.push(qj_over_qji_per_modqi_all_k);
+            qj_over_qji_per_modspecialpj_all_k_at_level.push(qj_over_qji_per_modspecialpj_all_k);
+
+            let alpha = (q_moduli_chain_at_level.len() as f64 / dnum as f64).ceil() as usize;
+            alpha_at_level.push(alpha);
+        }
+
+        // Parameters to switch v \in QP_s to (1/P)v \in Q //
+        // P_s is independent of level so the precomputes to switch and scale by 1/P_s a
+        // polynomial in QP_s (where Q is modulus at level) to Q remain unchanged
+        let mut specialp_over_specialpj = vec![];
+        let mut specialp_over_specialpj_inv_modspecialpj = vec![];
+        for pj in specialp_moduli_chain.iter() {
+            let tmp = &big_specialp / *pj;
+            specialp_over_specialpj_inv_modspecialpj.push(
+                mod_inverse_big_unit(&tmp, &BigUint::from_u64(*pj).unwrap())
+                    .to_u64()
+                    .unwrap(),
+            );
+            specialp_over_specialpj.push(tmp);
+        }
+        let mut specialp_over_specialpj_per_modqi = vec![];
+        let mut specialp_inv_modqi = vec![];
+        for qi in q_moduli_chain.iter() {
+            let modqi = NativeModulusBackend::initialise(*qi);
+            let tmp = specialp_over_specialpj
+                .iter()
+                .map(|v| modqi.normal_to_mont_space((v % *qi).to_u64().unwrap()))
+                .collect_vec();
+            specialp_over_specialpj_per_modqi.push(tmp);
+
+            specialp_inv_modqi.push(
+                mod_inverse_big_unit(&big_specialp, &BigUint::from_u64(*qi).unwrap())
+                    .to_u64()
+                    .unwrap(),
+            );
+        }
+
+        let q_modops = q_moduli_chain
+            .iter()
+            .map(|qi| NativeModulusBackend::initialise(*qi))
+            .collect_vec();
+        let specialp_modops = specialp_moduli_chain
+            .iter()
+            .map(|pj| NativeModulusBackend::initialise(*pj))
+            .collect_vec();
+        let q_nttops = q_moduli_chain
+            .iter()
+            .map(|qi| NativeNTTBackend::init(*qi, ring_size))
+            .collect_vec();
+        let specialp_nttops = specialp_moduli_chain
+            .iter()
+            .map(|pj| NativeNTTBackend::init(*pj, ring_size))
+            .collect_vec();
+
+        HybridKskParametersScalarU64 {
+            q_modops,
+            specialp_modops,
+            q_nttops,
+            specialp_nttops,
+
+            // KSK key gen //
+            gammak_modqi_at_level,
+
+            // KSK runtime //
+            qj_over_qji_inv_modqji_all_k_at_level,
+            qj_over_qji_per_modqi_all_k_at_level,
+            qj_over_qji_per_modspecialpj_all_k_at_level,
+            specialp_over_specialpj_inv_modspecialpj,
+            specialp_over_specialpj_per_modqi,
+            specialp_inv_modqi,
+
+            q_moduli_chain: q_moduli_chain.to_vec(),
+            specialp_moduli_chain: specialp_moduli_chain.to_vec(),
+            dnum,
+            q_moduli_chain_len: q_moduli_chain.len(),
+            ring_size,
+            alpha_at_level,
+        }
+    }
+
+    fn q_union_speciap_size_at_level(&self, level: usize) -> usize {
+        self.q_moduli_chain_len - level + self.specialp_moduli_chain.len()
+    }
+}
+
+impl Parameters for HybridKskParametersScalarU64 {
+    type Scalar = u64;
+}
+
+impl HybridKskKeyGenParameters for HybridKskParametersScalarU64 {
+    type ModOp = NativeModulusBackend;
+    type NttOp = NativeNTTBackend;
+
+    fn dnum(&self) -> usize {
+        self.dnum
+    }
+
+    fn gammak_modqi_at_level(&self, level: usize) -> &[Vec<Self::Scalar>] {
+        self.gammak_modqi_at_level[level].as_slice()
+    }
+
+    fn q_modops_at_level(&self, level: usize) -> &[Self::ModOp] {
+        &self.q_modops[..self.q_moduli_chain_len - level]
+    }
+
+    fn q_moduli_chain_at_level(&self, level: usize) -> &[Self::Scalar] {
+        &self.q_moduli_chain[..self.q_moduli_chain_len - level]
+    }
+
+    fn q_nttops_at_level(&self, level: usize) -> &[Self::NttOp] {
+        &self.q_nttops[..self.q_moduli_chain_len - level]
+    }
+
+    fn specialp_modops_at_level(&self, level: usize) -> &[Self::ModOp] {
+        &self.specialp_modops
+    }
+
+    fn specialp_nttops_at_level(&self, level: usize) -> &[Self::NttOp] {
+        &self.specialp_nttops
+    }
+
+    fn ring_size(&self) -> usize {
+        self.ring_size
+    }
+
+    fn specialp_moduli_chain_at_level(&self) -> &[Self::Scalar] {
+        &self.specialp_moduli_chain
+    }
+
+    fn alpha_at_level(&self, level: usize) -> usize {
+        self.alpha_at_level[level]
+    }
+}
+
+impl HybridKskRuntimeParameters for HybridKskParametersScalarU64 {
+    type ModOp = NativeModulusBackend;
+    type NttOp = NativeNTTBackend;
+
+    fn dnum(&self) -> usize {
+        self.dnum
+    }
+
+    fn ring_size(&self) -> usize {
+        self.ring_size
+    }
+
+    fn q_modops_at_level(&self, level: usize) -> &[Self::ModOp] {
+        &self.q_modops[..self.q_moduli_chain_len - level]
+    }
+
+    fn q_moduli_chain_at_level(&self, level: usize) -> &[Self::Scalar] {
+        &self.q_moduli_chain[..self.q_moduli_chain_len - level]
+    }
+
+    fn q_nttops_at_level(&self, level: usize) -> &[Self::NttOp] {
+        &self.q_nttops[..self.q_moduli_chain_len - level]
+    }
+
+    fn specialp_modops_at_level(&self, level: usize) -> &[Self::ModOp] {
+        &self.specialp_modops
+    }
+
+    fn specialp_nttops_at_level(&self, level: usize) -> &[Self::NttOp] {
+        &self.specialp_nttops
+    }
+
+    fn qj_over_qji_inv_modqji_level(&self, level: usize) -> &[Vec<Self::Scalar>] {
+        &self.qj_over_qji_inv_modqji_all_k_at_level[level]
+    }
+
+    fn qj_over_qji_per_modqi_at_level(
+        &self,
+        level: usize,
+    ) -> &[Vec<Vec<MontgomeryScalar<Self::Scalar>>>] {
+        &self.qj_over_qji_per_modqi_all_k_at_level[level]
+    }
+
+    fn qj_over_qji_per_modspecialpj_at_level(
+        &self,
+        level: usize,
+    ) -> &[Vec<Vec<MontgomeryScalar<Self::Scalar>>>] {
+        &self.qj_over_qji_per_modspecialpj_all_k_at_level[level]
+    }
+
+    fn specialp_inv_modqi_at_level(&self, level: usize) -> &[Self::Scalar] {
+        &self.specialp_inv_modqi[..self.q_moduli_chain_len - level]
+    }
+
+    fn specialp_moduli_chain_at_level(&self, level: usize) -> &[Self::Scalar] {
+        &self.specialp_moduli_chain
+    }
+
+    fn specialp_over_specialpj_inv_modspecialpj_at_level(&self, level: usize) -> &[Self::Scalar] {
+        &self.specialp_over_specialpj_inv_modspecialpj
+    }
+
+    fn specialp_over_specialpj_per_modqi_at_level(
+        &self,
+        level: usize,
+    ) -> &[Vec<MontgomeryScalar<Self::Scalar>>] {
+        &self.specialp_over_specialpj_per_modqi[..self.q_moduli_chain_len - level]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use itertools::izip;
+    use rand::SeedableRng;
+    use rand_chacha::{rand_core::le, ChaCha8Rng};
+
+    use crate::{
+        core_crypto::{
+            matrix::{Matrix, MatrixMut},
+            modulus::ModulusVecBackend,
+            prime::generate_primes_vec,
+            random::{DefaultU64SeededRandomGenerator, InitWithSeed, RandomUniformDist},
+            ring::{
+                add_lazy_mut, backward, backward_lazy, foward, foward_lazy, mul_lazy_mut, neg_mut,
+            },
+        },
+        keys::SecretKey,
+        utils::{convert::TryConvertFrom, test_utils::TestTernarySecret},
+    };
+
+    use self::ops::{generate_key, keyswitch};
+
+    use super::*;
+
+    #[test]
+    fn hybird_key_switching_works() {
+        let hybrid_ksk_params = {
+            // Setup //
+            let ring_size = 1 << 3;
+            let q_moduli_chain_sizes = vec![50, 50, 50, 50, 40, 50, 40];
+            let dnum = 2;
+            let specialp_moduli_chain_sizes = vec![50, 50, 50];
+
+            let q_moduli_chain = &generate_primes_vec(&q_moduli_chain_sizes, ring_size, &[]);
+            let specialp_moduli_chain =
+                &generate_primes_vec(&specialp_moduli_chain_sizes, ring_size, &q_moduli_chain);
+
+            HybridKskParametersScalarU64::new(
+                q_moduli_chain,
+                &specialp_moduli_chain,
+                dnum,
+                ring_size,
+            )
+        };
+
+        let mut rng = DefaultU64SeededRandomGenerator::new();
+
+        // Test key switching at all levels from 0 till max_level
+        for level in (0..hybrid_ksk_params.q_moduli_chain.len()) {
+            // Test KSK //
+            {
+                let q_moduli_chain_at_level =
+                    HybridKskKeyGenParameters::q_moduli_chain_at_level(&hybrid_ksk_params, level);
+                let specialp_moduli_chain_at_level =
+                    HybridKskKeyGenParameters::specialp_moduli_chain_at_level(&hybrid_ksk_params);
+                let ring_size = HybridKskKeyGenParameters::ring_size(&hybrid_ksk_params);
+
+                let q_nttops_at_level =
+                    HybridKskKeyGenParameters::q_nttops_at_level(&hybrid_ksk_params, level);
+                let q_modops_at_level =
+                    HybridKskKeyGenParameters::q_modops_at_level(&hybrid_ksk_params, level);
+
+                let mut p1 =
+                    <Vec<Vec<u64>> as Matrix>::zeros(q_moduli_chain_at_level.len(), ring_size);
+                RandomUniformDist::random_fill(&mut rng, q_moduli_chain_at_level, &mut p1);
+
+                let secret = TestTernarySecret::new(&mut rng, ring_size);
+
+                // Create key switching keys
+                let mut ksk_polys = (0..(hybrid_ksk_params.alpha_at_level(level) * 2))
+                    .into_iter()
+                    .map(|_| {
+                        <Vec<Vec<u64>> as Matrix>::zeros(
+                            hybrid_ksk_params.q_union_speciap_size_at_level(level),
+                            ring_size,
+                        )
+                    })
+                    .collect_vec();
+                let mut seed = <ChaCha8Rng as SeedableRng>::Seed::default();
+                let mut p1_eval = p1.clone();
+                foward_lazy(&mut p1_eval, &q_nttops_at_level);
+                generate_key(
+                    &hybrid_ksk_params,
+                    level,
+                    &p1_eval,
+                    &secret,
+                    &mut ksk_polys,
+                    &mut seed,
+                    &mut rng,
+                );
+
+                // Check key switching keys correctly enrypt gamma values
+                {
+                    assert!(
+                        ksk_polys.len() == hybrid_ksk_params.alpha_at_level(level) * 2,
+                        "Ciphertext in Ksk:{} but expect 2*alpha:{} at level:{level}",
+                        ksk_polys.len(),
+                        2 * hybrid_ksk_params.alpha_at_level(level)
+                    );
+
+                    let specialp_nttops_at_level =
+                        HybridKskKeyGenParameters::specialp_nttops_at_level(
+                            &hybrid_ksk_params,
+                            level,
+                        );
+                    let specialp_modops_at_level =
+                        HybridKskKeyGenParameters::specialp_modops_at_level(
+                            &hybrid_ksk_params,
+                            level,
+                        );
+
+                    let qp_chain = q_moduli_chain_at_level
+                        .to_vec()
+                        .into_iter()
+                        .chain(specialp_moduli_chain_at_level.to_vec().into_iter())
+                        .collect_vec();
+                    let qp_modops = q_modops_at_level
+                        .to_vec()
+                        .into_iter()
+                        .chain(specialp_modops_at_level.to_vec())
+                        .collect_vec();
+                    // Note(Jay): Due to the way NativeNTTBackend handles generating psi, two
+                    // separately intialised instances of Ntt with same modulus and ring are not
+                    // compatible. Given ksk polynomials are in evaluation, hence we `Clone` the Ntt
+                    // instances which were used in hybrid key gen phase and avoid creating new
+                    // instances, because doing so will be incorrect.
+                    let qp_nttops = q_nttops_at_level
+                        .to_vec()
+                        .into_iter()
+                        .chain(specialp_nttops_at_level.to_vec())
+                        .collect_vec();
+
+                    for (gamma_k, c_k) in izip!(
+                        hybrid_ksk_params.gammak_modqi_at_level(level).iter(),
+                        ksk_polys.chunks_exact(2)
+                    ) {
+                        let mut c0 = c_k[0].clone();
+                        let mut c1 = c_k[1].clone();
+
+                        let mut s = <Vec<Vec<u64>>>::try_convert_from(secret.values(), &qp_chain);
+                        foward_lazy(&mut s, &qp_nttops);
+                        mul_lazy_mut(&mut c1, &s, &qp_modops);
+                        add_lazy_mut(&mut c0, &c1, &qp_modops);
+                        backward(&mut c0, &qp_nttops);
+
+                        let mut gamma_p1 = p1.clone();
+                        izip!(
+                            q_modops_at_level.iter(),
+                            gamma_p1.iter_rows_mut(),
+                            gamma_k.iter()
+                        )
+                        .for_each(|(modqi, r, g)| {
+                            modqi.scalar_mul_mod_vec(r.as_mut(), *g);
+                        });
+
+                        assert_eq!(c0[..q_moduli_chain_at_level.len()], gamma_p1);
+                    }
+                }
+
+                let mut p2 =
+                    <Vec<Vec<u64>> as Matrix>::zeros(q_moduli_chain_at_level.len(), ring_size);
+                RandomUniformDist::random_fill(&mut rng, q_moduli_chain_at_level, &mut p2);
+
+                // Create key switch ciphertext polynomials
+                let mut c0_out =
+                    <Vec<Vec<u64>> as Matrix>::zeros(q_moduli_chain_at_level.len(), ring_size);
+                let mut c1_out = c0_out.clone();
+                // Key switch
+                keyswitch(
+                    &p2,
+                    &mut c0_out,
+                    &mut c1_out,
+                    ksk_polys.as_slice(),
+                    &hybrid_ksk_params,
+                    level,
+                );
+
+                // Check key switch output ciphertext polynomials c0, c1 encrypt p1p2
+                let mut s =
+                    <Vec<Vec<u64>>>::try_convert_from(secret.values(), q_moduli_chain_at_level);
+                foward_lazy(&mut s, q_nttops_at_level); // c0 + c1*s
+                mul_lazy_mut(&mut c1_out, &s, q_modops_at_level);
+                add_lazy_mut(&mut c0_out, &c1_out, q_modops_at_level);
+                backward(&mut c0_out, q_nttops_at_level);
+                let p1p2_out_big =
+                    Vec::<BigUint>::try_convert_from(&c0_out, q_moduli_chain_at_level);
+
+                // Expected p1*p2
+                let mut p1p2_expected = p1.clone();
+                foward_lazy(&mut p1p2_expected, q_nttops_at_level);
+                foward_lazy(&mut p2, q_nttops_at_level);
+                mul_lazy_mut(&mut p1p2_expected, &p2, q_modops_at_level);
+                backward(&mut p1p2_expected, q_nttops_at_level);
+                let p1p2_expected_big =
+                    Vec::<BigUint>::try_convert_from(&p1p2_expected, q_moduli_chain_at_level);
+
+                izip!(p1p2_out_big.iter(), p1p2_expected_big.iter()).for_each(|(p0, p1)| {
+                    let bits = if p0 < &p1 {
+                        (p1 - p0).bits()
+                    } else {
+                        (p0 - p1).bits()
+                    };
+                    // The difference depends on error in key switching keys + rounding error from
+                    // $x \in R_QP -> (1/P x) \in R_Q$. Ideally it should not exceed more than a few
+                    // bits
+                    assert!(bits <= 4);
+                });
+            }
+        }
+    }
+}

--- a/src/schemes/hybrid_ksk/mod.rs
+++ b/src/schemes/hybrid_ksk/mod.rs
@@ -397,9 +397,9 @@ mod tests {
         let hybrid_ksk_params = {
             // Setup //
             let ring_size = 1 << 3;
-            let q_moduli_chain_sizes = vec![50, 50, 50, 50, 40, 50, 40];
+            let q_moduli_chain_sizes = vec![60, 60, 60, 60, 50, 40, 50];
             let dnum = 2;
-            let specialp_moduli_chain_sizes = vec![50, 50, 50];
+            let specialp_moduli_chain_sizes = vec![60, 60, 50];
 
             let q_moduli_chain = &generate_primes_vec(&q_moduli_chain_sizes, ring_size, &[]);
             let specialp_moduli_chain =

--- a/src/schemes/hybrid_ksk/ops.rs
+++ b/src/schemes/hybrid_ksk/ops.rs
@@ -310,8 +310,10 @@ pub fn keyswitch<
             let mut q_values = Vec::with_capacity(end - start);
             for j in start..end {
                 q_values.push(
-                    q_modops[j]
-                        .mul_mod_fast(*x.get_element(j, ri), qj_over_qji_inv_modqji[j - start]),
+                    q_modops[j].mul_mod_fast_lazy(
+                        *x.get_element(j, ri),
+                        qj_over_qji_inv_modqji[j - start],
+                    ),
                 );
             }
 
@@ -326,11 +328,11 @@ pub fn keyswitch<
                 // map q_values to mont space
                 let q_in_mont_space = q_values
                     .iter()
-                    .map(|v| modqi.normal_to_mont_space(*v))
+                    .map(|v| modqi.normal_to_mont_space_lazy(*v))
                     .collect_vec();
 
                 let tmp = modqi.mont_fma(&q_in_mont_space, &qj_over_qji_modqi);
-                let tmp = modqi.mont_to_normal(tmp);
+                let tmp = modqi.mont_to_normal_lazy(tmp);
                 q_till_start.set(index, ri, tmp)
             }
 
@@ -345,11 +347,11 @@ pub fn keyswitch<
                 // map q_values to mont space
                 let q_in_mont_space = q_values
                     .iter()
-                    .map(|v| modqi.normal_to_mont_space(*v))
+                    .map(|v| modqi.normal_to_mont_space_lazy(*v))
                     .collect_vec();
 
                 let tmp = modqi.mont_fma(&q_in_mont_space, &qj_over_qji_modqi);
-                let tmp = modqi.mont_to_normal(tmp);
+                let tmp = modqi.mont_to_normal_lazy(tmp);
                 q_from_end.set(index, ri, tmp)
             }
 
@@ -364,11 +366,11 @@ pub fn keyswitch<
                 // map q_values to mont space
                 let q_in_mont_space = q_values
                     .iter()
-                    .map(|v| modpj.normal_to_mont_space(*v))
+                    .map(|v| modpj.normal_to_mont_space_lazy(*v))
                     .collect_vec();
 
                 let tmp = modpj.mont_fma(&q_in_mont_space, &qj_over_qji_modpj);
-                let tmp = modpj.mont_to_normal(tmp);
+                let tmp = modpj.mont_to_normal_lazy(tmp);
                 specialp_all.set(index, ri, tmp);
             }
         }

--- a/src/schemes/mod.rs
+++ b/src/schemes/mod.rs
@@ -1,1 +1,2 @@
 pub(crate) mod bfv;
+pub(crate) mod hybrid_ksk;

--- a/src/utils/test_utils.rs
+++ b/src/utils/test_utils.rs
@@ -18,35 +18,3 @@ pub fn random_vec_in_fq<T: UnsignedInteger + rand::distributions::uniform::Sampl
         .take(size)
         .collect_vec()
 }
-
-pub struct TestRng {}
-
-impl RandomUniformDist<u64, Vec<Vec<u64>>> for TestRng {
-    fn random_ring_poly(&mut self, moduli_chain: &[u64], ring_size: usize) -> Vec<Vec<u64>> {
-        let mut rng = thread_rng();
-        moduli_chain
-            .iter()
-            .map(|qi| {
-                (&mut rng)
-                    .sample_iter(Uniform::new(0, *qi))
-                    .take(ring_size)
-                    .collect_vec()
-            })
-            .collect_vec()
-    }
-
-    fn random_vec_in_modulus(&mut self, modulus: u64, size: usize) -> Vec<u64> {
-        let rng = thread_rng();
-        rng.sample_iter(Uniform::new(0, modulus))
-            .take(size)
-            .collect_vec()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use itertools::izip;
-    use rand::{CryptoRng, RngCore};
-
-    use super::*;
-}

--- a/src/utils/test_utils.rs
+++ b/src/utils/test_utils.rs
@@ -1,20 +1,50 @@
 use std::{marker::PhantomData, os::unix::thread};
 
-use crate::core_crypto::{
-    matrix::{Matrix, MatrixMut},
-    num::UnsignedInteger,
-    random::RandomUniformDist,
+use crate::{
+    core_crypto::{
+        matrix::{Matrix, MatrixMut},
+        num::UnsignedInteger,
+        random::RandomUniformDist,
+    },
+    keys::SecretKey,
+    schemes::bfv::ops::generate_ternery_secret_with_hamming_weight,
 };
 use itertools::Itertools;
 use ndarray::{iter::Iter, Array2, ArrayBase, Axis, Dim, IndexLonger, ViewRepr};
-use rand::{distributions::Uniform, thread_rng, Rng};
+use rand::{distributions::Uniform, thread_rng, CryptoRng, Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
 
 pub fn random_vec_in_fq<T: UnsignedInteger + rand::distributions::uniform::SampleUniform>(
     size: usize,
     q: T,
 ) -> Vec<T> {
-    let rng = thread_rng();
+    let rng = ChaCha8Rng::from_seed([0u8; 32]);
     rng.sample_iter(Uniform::new(T::zero(), q))
         .take(size)
         .collect_vec()
+}
+
+pub struct TestTernarySecret {
+    values: Vec<i32>,
+}
+
+impl TestTernarySecret {
+    pub fn new<
+        R: RandomUniformDist<[u8], Parameters = u8>
+            + RandomUniformDist<usize, Parameters = usize>
+            + CryptoRng,
+    >(
+        rng: &mut R,
+        ring_size: usize,
+    ) -> Self {
+        let values = generate_ternery_secret_with_hamming_weight(rng, ring_size >> 1, ring_size);
+        TestTernarySecret { values }
+    }
+}
+
+impl SecretKey for TestTernarySecret {
+    type Scalar = i32;
+    fn values(&self) -> &[Self::Scalar] {
+        self.values.as_slice()
+    }
 }


### PR DESCRIPTION

1. Add `native_ntt_negacylic_mul` test for NTTs: Previous tests weren't enough. Simply checking round trip of NTT forward and backward does not guarantee correctness of NTT operation. 
2. Debug assert that `omega` is n^th root of unity in `find_primitive_root`: This is helpful to point failure mode for NTT init in debug mode.
3. Added ring operations: 
	1. `approximate_mod_down` and `approximate_switch_crt_basis` (both taken from [2018/153](https://eprint.iacr.org/2018/153.pdf)): Both operations are used in hybrid key switching. Note that for both functions inputs can be have lazy coefficients, but outputs are always have lazy coefficients. This is to save quite a few reductions during hybrid key switching. Added the test for `approximate_mod_down` as `approximate_mod_down_works`. This test suffices to test `approximate_switch_crt_basis` since it is called internally in `approximate_mod_down`. 
	2. Added multiple ring operations as wrapper around their vector counterparts: `neg_lazy_mut`, `sub_lazy_mut`, `reduce_from_lazy_mut`, `backward_lazy`. None of them are tested, since their vector counter parts are expected to be. 
4. Added lazy counterparts for `neg_mod_fast` and `sub_mod_fast` in `ModulusArithmeticBackend` as `neg_lazy_mod_fast` and `sub_lazy_mod_fast`. Both of them don't have tests yet. 
5. Added `normal_to_mont_space_lazy` and `mont_to_normal_lazy` to `MontgomeryBackend` as lazy counterparts to their respective non-lazy versions. Both `lazy` functions wrap around `mont_mul_lazy` instead of `mont_mul` unlike their non-lazy counterparts. The benefit is saving a single conditional check in each call. Also note that, counter to what function names suggest, the input range (this only applies to montgomery) for non-lazy and their lazy counterparts is same (i.e. [0, r) where r is wordsize, either u32/u64)
6. Found `mod_exponent` to be buggy. As a workaround, replaced the implementation with the one from BigUintDig. Finding the bug, correcting it, and implementing necessary tests are left as tasks for future (Issue #22). 
7. Implemented vanilla `negacyclic_mul`. This is used to test ring polynomial multiplication using Ntts. 
8. Added `TestTernarySecret` as an independent Secret meant to be used in tests. 
9. Implemented hybrid ksk: Refer to hybrid ksk notes for more information about the implementation. I will note a few points here: 
	1. Implementation is based on [2021/204](https://eprint.iacr.org/2021/204.pdf) section B.2.3 and [2019/688](https://eprint.iacr.org/2019/688.pdf)
	2. Necessary tests for checking correctness of key switching keys and key switching operation are added. 
	3. Default Hybrid ksk parameter struct implementation `HybridKskParametersScalarU64` does not handle the case where Q (usually at levels >= max_level-1) < $P_s$. In this case, there's a way to improve key switch run time further by dropping 1-2 primes from $P_s$ without losing accuracy. We assume that this will handled at parameter generation phase and hybrid key switching implementation assumes that $P_s$ can be different across levels. 
